### PR TITLE
feat: add remark-directive support for directive syntax

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "bun-types": "latest",
         "esbuild": "^0.27.4",
         "micromark-extension-mdx-expression": "^3.0.0",
+        "remark-directive": "^4.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
         "remark-math": "^6.0.0",
@@ -718,6 +719,8 @@
 
     "markdown-table": ["markdown-table@3.0.3", "", {}, "sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw=="],
 
+    "mdast-util-directive": ["mdast-util-directive@3.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q=="],
+
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA=="],
 
     "mdast-util-footnote": ["mdast-util-footnote@0.1.7", "", { "dependencies": { "mdast-util-to-markdown": "^0.6.0", "micromark": "~2.11.0" } }, "sha512-QxNdO8qSxqbO2e3m09KwDKfWiLgqyCurdWTQ198NpbZ2hxntdc+VKS4fDJCmNWbAroUdYnSthu+XbZ8ovh8C3w=="],
@@ -761,6 +764,8 @@
     "micromark": ["micromark@4.0.0", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.0", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA=="],
+
+    "micromark-extension-directive": ["micromark-extension-directive@4.0.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "parse-entities": "^4.0.0" } }, "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg=="],
 
     "micromark-extension-footnote": ["micromark-extension-footnote@0.3.2", "", { "dependencies": { "micromark": "~2.11.0" } }, "sha512-gr/BeIxbIWQoUm02cIfK7mdMZ/fbroRpLsck4kvFtjbzP4yi+OPVbnukTc/zy0i7spC2xYE/dbX1Sur8BEDJsQ=="],
 
@@ -929,6 +934,8 @@
     "regexpu-core": ["regexpu-core@5.3.2", "", { "dependencies": { "@babel/regjsgen": "^0.8.0", "regenerate": "^1.4.2", "regenerate-unicode-properties": "^10.1.0", "regjsparser": "^0.9.1", "unicode-match-property-ecmascript": "^2.0.0", "unicode-match-property-value-ecmascript": "^2.1.0" } }, "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ=="],
 
     "regjsparser": ["regjsparser@0.9.1", "", { "dependencies": { "jsesc": "~0.5.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ=="],
+
+    "remark-directive": ["remark-directive@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-directive": "^3.0.0", "micromark-extension-directive": "^4.0.0", "unified": "^11.0.0" } }, "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA=="],
 
     "remark-footnotes": ["remark-footnotes@3.0.0", "", { "dependencies": { "mdast-util-footnote": "^0.1.0", "micromark-extension-footnote": "^0.3.0" } }, "sha512-ZssAvH9FjGYlJ/PBVKdSmfyPc3Cz4rTWgZLI4iE/SX8Nt5l3o3oEjv3wwG5VD7xOjktzdwp5coac+kJV9l4jgg=="],
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
+		"remark-directive": "^4.0.0",
 		"remark-frontmatter": "^5.0.0",
 		"remark-gfm": "^4.0.0",
 		"remark-math": "^6.0.0",

--- a/src/mapping/markdown-syntax-map.ts
+++ b/src/mapping/markdown-syntax-map.ts
@@ -32,6 +32,10 @@ export const SyntaxMap = {
 	imageReference: "ImageReference",
 	footnoteReference: "FootnoteReference", // textlint@12+
 	definition: "Definition",
+	// remark-directive
+	textDirective: "TextDirective",
+	leafDirective: "LeafDirective",
+	containerDirective: "ContainerDirective",
 	/**
 	 * @deprecated
 	 */

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -19,9 +19,9 @@ export const parseMarkdown = (text: string): Node => {
 		.use(remarkParse)
 		.use(frontmatter, ["yaml"])
 		.use(remarkGfm)
+		.use(remarkDirective)
 		.use(remarkMdx)
-		.use(remarkMath)
-		.use(remarkDirective);
+		.use(remarkMath);
 	return remark.parse(text);
 };
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -111,6 +111,9 @@ export function parse(text: string): TxtDocumentNode {
 				} else {
 					node.type = replacedType;
 				}
+				if (Object.prototype.hasOwnProperty.call(node, "data")) {
+					node.data = undefined;
+				}
 			}
 			// map `range`, `loc` and `raw` to node
 			if (node.position) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,6 +6,7 @@ import { SyntaxMap } from "./mapping/markdown-syntax-map";
 
 import { unified } from "unified";
 
+import remarkDirective from "remark-directive";
 import frontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -19,7 +20,8 @@ export const parseMarkdown = (text: string): Node => {
 		.use(frontmatter, ["yaml"])
 		.use(remarkGfm)
 		.use(remarkMdx)
-		.use(remarkMath);
+		.use(remarkMath)
+		.use(remarkDirective);
 	return remark.parse(text);
 };
 
@@ -49,6 +51,10 @@ export function parse(text: string): TxtDocumentNode {
 			/^(mdxJsxFlowElement|mdxJsxTextElement|mdxjsEsm|mdxFlowExpression|mdxTextExpression)$/.test(
 				node.type,
 			);
+		const isDirective =
+			node &&
+			Object.prototype.hasOwnProperty.call(node, "type") &&
+			/^(textDirective|leafDirective|containerDirective)$/.test(node.type);
 		if (this.notLeaf) {
 			// MDX support
 			if (isMdx) {
@@ -79,6 +85,21 @@ export function parse(text: string): TxtDocumentNode {
 				}
 				if (Object.prototype.hasOwnProperty.call(node, "name")) {
 					node.name = undefined;
+				}
+				if (Object.prototype.hasOwnProperty.call(node, "data")) {
+					node.data = undefined;
+				}
+			} else if (isDirective) {
+				// remark-directive support
+				const replacedType = SyntaxMap[node.type as keyof typeof SyntaxMap];
+				if (replacedType) {
+					node.type = replacedType;
+				}
+				if (Object.prototype.hasOwnProperty.call(node, "name")) {
+					node.name = undefined;
+				}
+				if (Object.prototype.hasOwnProperty.call(node, "attributes")) {
+					node.attributes = undefined;
 				}
 				if (Object.prototype.hasOwnProperty.call(node, "data")) {
 					node.data = undefined;

--- a/test/fixtures/containerDirective/input.mdx
+++ b/test/fixtures/containerDirective/input.mdx
@@ -1,0 +1,3 @@
+:::note[Note title]
+Content here.
+:::

--- a/test/fixtures/containerDirective/output.json
+++ b/test/fixtures/containerDirective/output.json
@@ -1,0 +1,103 @@
+{
+	"type": "Document",
+	"children": [
+		{
+			"type": "ContainerDirective",
+			"children": [
+				{
+					"type": "Paragraph",
+					"data": {
+						"directiveLabel": true
+					},
+					"children": [
+						{
+							"type": "Str",
+							"value": "Note title",
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 8
+								},
+								"end": {
+									"line": 1,
+									"column": 18
+								}
+							},
+							"range": [8, 18],
+							"raw": "Note title"
+						}
+					],
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 7
+						},
+						"end": {
+							"line": 1,
+							"column": 19
+						}
+					},
+					"range": [7, 19],
+					"raw": "[Note title]"
+				},
+				{
+					"type": "Paragraph",
+					"children": [
+						{
+							"type": "Str",
+							"value": "Content here.",
+							"loc": {
+								"start": {
+									"line": 2,
+									"column": 0
+								},
+								"end": {
+									"line": 2,
+									"column": 13
+								}
+							},
+							"range": [20, 33],
+							"raw": "Content here."
+						}
+					],
+					"loc": {
+						"start": {
+							"line": 2,
+							"column": 0
+						},
+						"end": {
+							"line": 2,
+							"column": 13
+						}
+					},
+					"range": [20, 33],
+					"raw": "Content here."
+				}
+			],
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 3,
+					"column": 3
+				}
+			},
+			"range": [0, 37],
+			"raw": ":::note[Note title]\nContent here.\n:::"
+		}
+	],
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 4,
+			"column": 0
+		}
+	},
+	"range": [0, 38],
+	"raw": ":::note[Note title]\nContent here.\n:::\n"
+}

--- a/test/fixtures/containerDirective/output.json
+++ b/test/fixtures/containerDirective/output.json
@@ -20,10 +20,7 @@
 									"column": 18
 								}
 							},
-							"range": [
-								8,
-								18
-							],
+							"range": [8, 18],
 							"raw": "Note title"
 						}
 					],
@@ -37,10 +34,7 @@
 							"column": 19
 						}
 					},
-					"range": [
-						7,
-						19
-					],
+					"range": [7, 19],
 					"raw": "[Note title]"
 				},
 				{
@@ -59,10 +53,7 @@
 									"column": 13
 								}
 							},
-							"range": [
-								20,
-								33
-							],
+							"range": [20, 33],
 							"raw": "Content here."
 						}
 					],
@@ -76,10 +67,7 @@
 							"column": 13
 						}
 					},
-					"range": [
-						20,
-						33
-					],
+					"range": [20, 33],
 					"raw": "Content here."
 				}
 			],
@@ -93,10 +81,7 @@
 					"column": 3
 				}
 			},
-			"range": [
-				0,
-				37
-			],
+			"range": [0, 37],
 			"raw": ":::note[Note title]\nContent here.\n:::"
 		}
 	],
@@ -110,9 +95,6 @@
 			"column": 0
 		}
 	},
-	"range": [
-		0,
-		38
-	],
+	"range": [0, 38],
 	"raw": ":::note[Note title]\nContent here.\n:::\n"
 }

--- a/test/fixtures/containerDirective/output.json
+++ b/test/fixtures/containerDirective/output.json
@@ -6,9 +6,6 @@
 			"children": [
 				{
 					"type": "Paragraph",
-					"data": {
-						"directiveLabel": true
-					},
 					"children": [
 						{
 							"type": "Str",
@@ -23,7 +20,10 @@
 									"column": 18
 								}
 							},
-							"range": [8, 18],
+							"range": [
+								8,
+								18
+							],
 							"raw": "Note title"
 						}
 					],
@@ -37,7 +37,10 @@
 							"column": 19
 						}
 					},
-					"range": [7, 19],
+					"range": [
+						7,
+						19
+					],
 					"raw": "[Note title]"
 				},
 				{
@@ -56,7 +59,10 @@
 									"column": 13
 								}
 							},
-							"range": [20, 33],
+							"range": [
+								20,
+								33
+							],
 							"raw": "Content here."
 						}
 					],
@@ -70,7 +76,10 @@
 							"column": 13
 						}
 					},
-					"range": [20, 33],
+					"range": [
+						20,
+						33
+					],
 					"raw": "Content here."
 				}
 			],
@@ -84,7 +93,10 @@
 					"column": 3
 				}
 			},
-			"range": [0, 37],
+			"range": [
+				0,
+				37
+			],
 			"raw": ":::note[Note title]\nContent here.\n:::"
 		}
 	],
@@ -98,6 +110,9 @@
 			"column": 0
 		}
 	},
-	"range": [0, 38],
+	"range": [
+		0,
+		38
+	],
 	"raw": ":::note[Note title]\nContent here.\n:::\n"
 }

--- a/test/fixtures/leafDirective/input.mdx
+++ b/test/fixtures/leafDirective/input.mdx
@@ -1,0 +1,1 @@
+::youtube[Video title]{#abc123}

--- a/test/fixtures/leafDirective/output.json
+++ b/test/fixtures/leafDirective/output.json
@@ -1,0 +1,50 @@
+{
+	"type": "Document",
+	"children": [
+		{
+			"type": "LeafDirective",
+			"children": [
+				{
+					"type": "Str",
+					"value": "Video title",
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 10
+						},
+						"end": {
+							"line": 1,
+							"column": 21
+						}
+					},
+					"range": [10, 21],
+					"raw": "Video title"
+				}
+			],
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 31
+				}
+			},
+			"range": [0, 31],
+			"raw": "::youtube[Video title]{#abc123}"
+		}
+	],
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 0
+		}
+	},
+	"range": [0, 32],
+	"raw": "::youtube[Video title]{#abc123}\n"
+}

--- a/test/fixtures/textDirective/input.mdx
+++ b/test/fixtures/textDirective/input.mdx
@@ -1,0 +1,1 @@
+Read the :abbr[HTML]{title="HyperText Markup Language"} spec.

--- a/test/fixtures/textDirective/output.json
+++ b/test/fixtures/textDirective/output.json
@@ -1,0 +1,99 @@
+{
+	"type": "Document",
+	"children": [
+		{
+			"type": "Paragraph",
+			"children": [
+				{
+					"type": "Str",
+					"value": "Read the ",
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 0
+						},
+						"end": {
+							"line": 1,
+							"column": 9
+						}
+					},
+					"range": [0, 9],
+					"raw": "Read the "
+				},
+				{
+					"type": "TextDirective",
+					"children": [
+						{
+							"type": "Str",
+							"value": "HTML",
+							"loc": {
+								"start": {
+									"line": 1,
+									"column": 15
+								},
+								"end": {
+									"line": 1,
+									"column": 19
+								}
+							},
+							"range": [15, 19],
+							"raw": "HTML"
+						}
+					],
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 9
+						},
+						"end": {
+							"line": 1,
+							"column": 55
+						}
+					},
+					"range": [9, 55],
+					"raw": ":abbr[HTML]{title=\"HyperText Markup Language\"}"
+				},
+				{
+					"type": "Str",
+					"value": " spec.",
+					"loc": {
+						"start": {
+							"line": 1,
+							"column": 55
+						},
+						"end": {
+							"line": 1,
+							"column": 61
+						}
+					},
+					"range": [55, 61],
+					"raw": " spec."
+				}
+			],
+			"loc": {
+				"start": {
+					"line": 1,
+					"column": 0
+				},
+				"end": {
+					"line": 1,
+					"column": 61
+				}
+			},
+			"range": [0, 61],
+			"raw": "Read the :abbr[HTML]{title=\"HyperText Markup Language\"} spec."
+		}
+	],
+	"loc": {
+		"start": {
+			"line": 1,
+			"column": 0
+		},
+		"end": {
+			"line": 2,
+			"column": 0
+		}
+	},
+	"range": [0, 62],
+	"raw": "Read the :abbr[HTML]{title=\"HyperText Markup Language\"} spec.\n"
+}


### PR DESCRIPTION
## Summary

I use [directive syntax](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444) in my MDX files and want to lint them with textlint. However, the plugin currently throws a parse error when a directive with attributes is encountered — e.g., `::directive[foo]{bar=baz qux=quux}`.

The root cause is that `remark-mdx` treats the `{...}` part of a directive as an MDX/JSX expression and tries to parse its content as JavaScript. Attribute syntax like `{key1=val1 key2=val2}` is not valid JavaScript expression, so parsing fails.

## Fix

This PR integrates [`remark-directive`](https://github.com/remarkjs/remark-directive) into the plugin's remark pipeline. By adding it before `remark-mdx` processes the AST, directive nodes (`textDirective`, `leafDirective`, `containerDirective`) are recognized and parsed correctly instead of being handed off to the MDX expression parser.

The three directive node types are mapped to custom textlint AST node types (`TextDirective`, `LeafDirective`, `ContainerDirective`), and directive-specific properties (`name`, `attributes`, `data`) are stripped to keep the AST clean.

## Test plan

- [x] Added fixtures for all three directive types (`textDirective`, `leafDirective`, `containerDirective`)
- [x] All existing tests continue to pass