### PR TITLE
fix: remove unnecessary TypeScript peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,9 +27,6 @@
         "unified": "^11.0.4",
         "vitest": "^1.4.0",
       },
-      "peerDependencies": {
-        "typescript": "^5.0.0",
-      },
     },
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
 		"vitest": "^1.4.0"
 	},
 	"peerDependencies": {
-		"typescript": "^5.0.0"
+		"typescript": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,5 @@
 		"textlint-tester": "^14.0.4",
 		"typescript": "^5.4.3",
 		"vitest": "^1.4.0"
-	},
-	"peerDependencies": {
-		"typescript": "*"
 	}
 }


### PR DESCRIPTION
## Summary

Widens `peerDependencies.typescript` from `^5.0.0` to `*`.

## Background

The `typescript` package is only used for type-checking during development — the plugin's source never imports it, and the published `lib/index.js` is a self-contained esbuild bundle with no `.d.ts` output. Despite that, pinning the peer range to `^5.0.0` makes consumers on TypeScript 6 hit an unmet-peer warning, as reported in #19, and can end up being a reason a downstream project can't upgrade its own TypeScript version.

`textlint-scripts`, itself a dependency of this plugin, already treats `typescript` as an optional peer with a permissive `"*"` range. This change aligns the plugin with that same policy.

## Test plan

- [x] `bun run tsc`
- [x] `bun run ci` (biome)
- [x] `bun run build`
- [x] `bun run test -- --run`

Closes #19